### PR TITLE
Add Shutdown Handler

### DIFF
--- a/packages/helios/src/index.ts
+++ b/packages/helios/src/index.ts
@@ -28,6 +28,10 @@ export class Helios extends Device {
     }
   }
 
+  onShutdownSync() {
+    heliosLib.closeDevices();
+  }
+
   private convertPoint(p: heliosLib.IPoint) {
     return {
       x: relativeToPosition(p.x),


### PR DESCRIPTION
Original PR description by sterlinghirsh:

My laser (via helios) would stay on when I'd shut down the program, so I added a shutdown handler for safety and convenience.

I didn't add it for any other devices since I don't have any to test, but it should be a simple change to add it.